### PR TITLE
Added scope to track event callback 

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -295,7 +295,7 @@ angular.module('angulartics', [])
         if($attrs.analyticsProperties){
           angular.extend(trackingData, $scope.$eval($attrs.analyticsProperties));
         }
-        $analytics.eventTrack(eventName, trackingData);
+        $analytics.eventTrack(eventName, trackingData, $scope);
       });
     }
   };


### PR DESCRIPTION
Added scope to track event callback to allow for extension of dynamic data gathering. Now one can gather data from the scope of the element being tracked.
